### PR TITLE
Updated to work with more recent dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a [buildpack](http://devcenter.heroku.com/articles/buildpacks) for FUSE 
 ## History and Status
 The buildpack is forked from `znetstar/heroku-buildpack-s3fs`, which apparently written for heroku. Znetstar's built both fuse and s3fs-fuse binaries properly but did not mount the filesystem. On heroku, I was hitting permission errors related to `modprobe` trying to mount a filesystem. I thought it was because fuse capacity is not compiled with heroku host OS, or it was not exposed to its app container. I suspected the problem could not be fixed, until Heorku decided to enable fuse. (Please kindly let me know if I was mistaken).
 
-I ported the script to [dokku](https://github.com/progrium/dokku) and was able to get it to work, with [dokku v3.0.2](https://github.com/progrium/dokku/releases/tag/v0.3.12). (see, #catches section below)
+I ported the script to [dokku](https://github.com/progrium/dokku) and was able to get it to work, with [dokku v0.3.26](https://github.com/progrium/dokku/releases/tag/v0.3.26). (see, #catches section below)
 
 ## How it Works
 This buildpack downloads both fuse and s3fs-fuse projects from its project locations (sourceforge and github respectively), builds the binaries and mount a single s3 bucket with a single location.
@@ -35,32 +35,14 @@ cd << project root >>   # your local git repo
 echo https://github.com/beedesk/dokku-buildpack-s3fs.git >> .buildpacks
 ```
 
-Fuse and s3fs-fuse require additional privileges that need to be specified. This [docker-options](https://github.com/dyson/dokku-docker-options) plugin can be used.
+Fuse and s3fs-fuse require additional privileges that need to be specified. Earlier versions of dokku (such as v3.0.11) requires  [docker-options](https://github.com/dyson/dokku-docker-options) plugin. Newer versions (such as v3.0.26) has it builtin. The syntax is slightly different. The text below is for newer version.
 
 ```bash
-cd << vagrant root >>    # 
-vagrant ssh              # or, ssh -i ec2@private.pem ec2....
-
-# once you login 
-cd /var/lib/dokku/plugins
-sudo git clone https://github.com/dyson/dokku-docker-options
-
-sudo su - dokku
-dokku                    # now you should see these new options displayed:
-                         #     docker-options:add <app> OPTIONS_STRING  add an option string an app
-                         #     docker-options <app> display docker options for an app
-                         
-dokku docker-options:add << app name >> "--cap-add mknod --cap-add=sys_admin --device=/dev/fuse"
+dokku docker-options:add << app name >> "run --cap-add mknod --cap-add=sys_admin --device=/dev/fuse"
 
                          # Note 1:
                          # See, this issue [Docker with FUSE](https://github.com/docker/docker/issues/9448)
                          # if you get need to understand the options
-                         #
-                         # Note 2:
-                         # At this time, I was not able to change the docker-options once I added it. If
-                         # you hit the same bug, ssh in and edit /home/dokku/<< app name >>/DOCKER_OPTIONS
-
-exit                     # Exit ssh        
 ```
 
 Now, follow these steps to deploy the project

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ echo https://github.com/beedesk/dokku-buildpack-s3fs.git >> .buildpacks
 Fuse and s3fs-fuse require additional privileges that need to be specified. Earlier versions of dokku (such as v3.0.11) requires  [docker-options](https://github.com/dyson/dokku-docker-options) plugin. Newer versions (such as v3.0.26) has it builtin. The syntax is slightly different. The text below is for newer version.
 
 ```bash
-dokku docker-options:add << app name >> "run --cap-add mknod --cap-add=sys_admin --device=/dev/fuse"
+dokku docker-options:add << app name >> "deploy --privileged --cap-add=MKNOD --cap-add=SYS_ADMIN --device=/dev/fuse"
+dokku docker-options:add << app name >> "run --privileged --cap-add=MKNOD --cap-add=SYS_ADMIN --device=/dev/fuse"
 
                          # Note 1:
                          # See, this issue [Docker with FUSE](https://github.com/docker/docker/issues/9448)

--- a/bin/compile
+++ b/bin/compile
@@ -4,11 +4,11 @@
 # version
 #
 fuse_version_major=2
-fuse_version_minor=9.3
+fuse_version_minor=9.4
 s3fs_version=1.78
 
 fuse_archive_filename=fuse-${fuse_version_major}.${fuse_version_minor}.tar.gz
-fuse_download_url=http://hivelocity.dl.sourceforge.net/project/fuse/fuse-${fuse_version_major}.X/${fuse_version_major}.${fuse_version_minor}/${fuse_archive_filename}
+fuse_download_url=http://www.sourceforge.net/projects/fuse/files/fuse-${fuse_version_major}.X/${fuse_version_major}.${fuse_version_minor}/${fuse_archive_filename}
 
 s3fs_archive_filename=s3fs-fuse-${s3fs_version}.tar.gz
 s3fs_download_url=https://codeload.github.com/s3fs-fuse/s3fs-fuse/tar.gz/v${s3fs_version}

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ fuse_version_minor=9.4
 s3fs_version=1.78
 
 fuse_archive_filename=fuse-${fuse_version_major}.${fuse_version_minor}.tar.gz
-fuse_download_url=http://www.sourceforge.net/projects/fuse/files/fuse-${fuse_version_major}.X/${fuse_version_major}.${fuse_version_minor}/${fuse_archive_filename}
+fuse_download_url=http://skylineservers.dl.sourceforge.net/project/fuse/fuse-${fuse_version_major}.X/${fuse_version_major}.${fuse_version_minor}/${fuse_archive_filename}
 
 s3fs_archive_filename=s3fs-fuse-${s3fs_version}.tar.gz
 s3fs_download_url=https://codeload.github.com/s3fs-fuse/s3fs-fuse/tar.gz/v${s3fs_version}

--- a/bin/compile
+++ b/bin/compile
@@ -79,9 +79,10 @@ if [ ! -f "$build_dir/s3fs/s3_built" ]; then
 	touch $build_dir/s3fs/s3_built
 fi
 
-# Create Mount point
-if [ ! -f ~/$S3FS_AWS_MOUNT_POINT ]; then
-    mkdir -pv ~/$S3FS_AWS_MOUNT_POINT
+# Ensure Mount point is set
+if [ -z ${S3FS_AWS_MOUNT_POINT} ]; then
+    echo "Expect 'S3FS_AWS_MOUNT_POINT' to be set"
+    exit 1
 fi
 
 #
@@ -95,25 +96,26 @@ echo "export PATH=\$HOME/s3fs/bin:\$HOME/s3fs/usr/bin:\$HOME/s3fs/usr/sbin:\$HOM
 
 # Mount with .profile.d script which is running as root (will it change in the future?)
 cat >> $build_dir/.profile.d/s3fs.sh << EOF
-echo \${S3FS_AWS_ACCESS_KEY_ID:=\$AWS_ACCESS_KEY_ID}:\${S3FS_AWS_SECRET_ACCESS_KEY:=\$AWS_SECRET_ACCESS_KEY} > .passwd-s3fs
-chmod 600 .passwd-s3fs
+echo \${S3FS_AWS_ACCESS_KEY_ID:=\$AWS_ACCESS_KEY_ID}:\${S3FS_AWS_SECRET_ACCESS_KEY:=\$AWS_SECRET_ACCESS_KEY} > ~/.passwd-s3fs
+chmod 600 ~/.passwd-s3fs
 
 # Create directories
-if [ ! -d "\${S3FS_AWS_MOUNT_POINT}" ]; then
-  mkdir -p \${S3FS_AWS_MOUNT_POINT}
-  chmod 777 \${S3FS_AWS_MOUNT_POINT}
+if [ ! -d "~/\${S3FS_AWS_MOUNT_POINT}" ]; then
+  echo "Creating a mount point: ~\${S3FS_AWS_MOUNT_POINT}"
+  mkdir -pv ~/\${S3FS_AWS_MOUNT_POINT}
+  chmod 777 ~/\${S3FS_AWS_MOUNT_POINT}
 fi
 
 if [ ! -d "\${S3FS_CACHE_DIR:="/tmp/s3fs"}" ]; then
-  mkdir -p \${S3FS_CACHE_DIR}
+  mkdir -pv \${S3FS_CACHE_DIR}
 fi
 
 # Options
 echo "Mounting with options " \${S3FS_MOUNT_OPTIONS:="-o allow_other -o use_cache=\${S3FS_CACHE_DIR}"}
 
 # Mount
-echo "Executing: " \${S3_CMD}  \${S3FS_AWS_S3_BUCKET_NAME:=\$AWS_S3_BUCKET_NAME} \$S3FS_AWS_MOUNT_POINT \${S3FS_MOUNT_OPTIONS}
-\${S3_CMD} -o allow_other \${S3FS_AWS_S3_BUCKET_NAME:=\$AWS_S3_BUCKET_NAME} \$S3FS_AWS_MOUNT_POINT \${S3FS_MOUNT_OPTIONS}
+echo "Executing: " \${S3_CMD}  \${S3FS_AWS_S3_BUCKET_NAME:=\$AWS_S3_BUCKET_NAME} ~/\$S3FS_AWS_MOUNT_POINT \${S3FS_MOUNT_OPTIONS}
+\${S3_CMD} -o allow_other \${S3FS_AWS_S3_BUCKET_NAME:=\$AWS_S3_BUCKET_NAME} ~/\$S3FS_AWS_MOUNT_POINT \${S3FS_MOUNT_OPTIONS}
 echo "s3fs exited with " \$?
 EOF
 

--- a/bin/compile
+++ b/bin/compile
@@ -96,27 +96,36 @@ echo "export PATH=\$HOME/s3fs/bin:\$HOME/s3fs/usr/bin:\$HOME/s3fs/usr/sbin:\$HOM
 
 # Mount with .profile.d script which is running as root (will it change in the future?)
 cat >> $build_dir/.profile.d/s3fs.sh << EOF
-echo \${S3FS_AWS_ACCESS_KEY_ID:=\$AWS_ACCESS_KEY_ID}:\${S3FS_AWS_SECRET_ACCESS_KEY:=\$AWS_SECRET_ACCESS_KEY} > ~/.passwd-s3fs
-chmod 600 ~/.passwd-s3fs
+whoami
+if [ -z "\$S3FS_DISABLE_MOUNT" ]; then
+    echo \${S3FS_AWS_ACCESS_KEY_ID:=\$AWS_ACCESS_KEY_ID}:\${S3FS_AWS_SECRET_ACCESS_KEY:=\$AWS_SECRET_ACCESS_KEY} > ~/.passwd-s3fs
+    chmod 600 ~/.passwd-s3fs
 
-# Create directories
-if [ ! -d "~/\${S3FS_AWS_MOUNT_POINT}" ]; then
-  echo "Creating a mount point: ~\${S3FS_AWS_MOUNT_POINT}"
-  mkdir -pv ~/\${S3FS_AWS_MOUNT_POINT}
-  chmod 777 ~/\${S3FS_AWS_MOUNT_POINT}
+    # Create directories
+    if [ ! -d "~/\${S3FS_AWS_MOUNT_POINT}" ]; then
+        echo "Creating a mount point: ~/\${S3FS_AWS_MOUNT_POINT}"
+        mkdir -pv ~/\${S3FS_AWS_MOUNT_POINT}
+        chmod 777 ~/\${S3FS_AWS_MOUNT_POINT}
+    fi
+
+    if [ ! -d "\${S3FS_CACHE_DIR:="/tmp/fusecache/s3fs"}" ]; then
+        echo "Creating a cache dir: \${S3FS_CACHE_DIR}"
+        mkdir -pv \${S3FS_CACHE_DIR}
+        chmod 777 \${S3FS_CACHE_DIR}
+    fi
+
+    # Options
+    echo "Mounting with options " \${S3FS_MOUNT_OPTIONS:="-o allow_other -o use_cache=\${S3FS_CACHE_DIR}"}
+
+    # Mount
+    echo "Executing: " \${S3_CMD}  \${S3FS_AWS_S3_BUCKET_NAME:=\$AWS_S3_BUCKET_NAME} ~/\$S3FS_AWS_MOUNT_POINT \${S3FS_MOUNT_OPTIONS}
+    \${S3_CMD} -o allow_other \${S3FS_AWS_S3_BUCKET_NAME:=\$AWS_S3_BUCKET_NAME} ~/\$S3FS_AWS_MOUNT_POINT \${S3FS_MOUNT_OPTIONS}
+    echo "s3fs exited with " \$?
+else
+    echo "Flag S3FS_DISABLE_MOUNT is set. Skip mount step."
 fi
 
-if [ ! -d "\${S3FS_CACHE_DIR:="/tmp/s3fs"}" ]; then
-  mkdir -pv \${S3FS_CACHE_DIR}
-fi
-
-# Options
-echo "Mounting with options " \${S3FS_MOUNT_OPTIONS:="-o allow_other -o use_cache=\${S3FS_CACHE_DIR}"}
-
-# Mount
-echo "Executing: " \${S3_CMD}  \${S3FS_AWS_S3_BUCKET_NAME:=\$AWS_S3_BUCKET_NAME} ~/\$S3FS_AWS_MOUNT_POINT \${S3FS_MOUNT_OPTIONS}
-\${S3_CMD} -o allow_other \${S3FS_AWS_S3_BUCKET_NAME:=\$AWS_S3_BUCKET_NAME} ~/\$S3FS_AWS_MOUNT_POINT \${S3FS_MOUNT_OPTIONS}
-echo "s3fs exited with " \$?
 EOF
 
+cd ~
 exit 0


### PR DESCRIPTION
- newer docker (apt-get lxc-docker 1.7)
- newer dokku version (v3.0.26) 
- new fuse version (2.9.4) 

Fixed default cache directory. Improved error message for a few cases.
